### PR TITLE
Added MQTT username & password config options

### DIFF
--- a/config/remeha.conf
+++ b/config/remeha.conf
@@ -9,6 +9,8 @@
 	    "enabled": true,
 	    "host": "localhost",
 	    "port": 1883,
+	    "user_name": null,
+	    "password": null,
 	    "comment-topic": "specify the topic every value will be published to.",
 	    "topic": "boiler/",
 	    "log_values": ["outside_temp", "flow_temp", "return_temp", "calorifier_temp", "airflow_actual"],

--- a/mqtt_logger.py
+++ b/mqtt_logger.py
@@ -25,6 +25,9 @@ class LogToMQtt:
                 self.client = mqttClient.Client("Python")
                 self.translator = Translator()
                 try:
+                    if 'user_name' in self.config and self.config['user_name'] is not None:
+                        password = None if 'password' not in self.config else self.config['password']
+                        self.client.username_pw_set(self.config['user_name'], password=password )
                     self.client.connect(host=self.config['host'], port=self.config['port'])
                 except Exception:
                     self.client = None
@@ -56,6 +59,9 @@ class LogToMQtt:
         if 'port' not in config:
             self.config = None
             log.error('missing "port" in "mqtt_logger" config section')
+        if 'password' in config and config['password'] is not None and 'user_name' not in config:
+            self.config = None
+            log.error('missing "user_name" in "mqtt_logger" config section')
         if 'log_values' in config:
             self.log_single_value_list = config['log_values']
         if 'log_values_with_duration' in config:

--- a/mqtt_logger.py
+++ b/mqtt_logger.py
@@ -59,7 +59,7 @@ class LogToMQtt:
         if 'port' not in config:
             self.config = None
             log.error('missing "port" in "mqtt_logger" config section')
-        if 'password' in config and config['password'] is not None and 'user_name' not in config:
+        if 'password' in config and config['password'] is not None and ('user_name' not in config or config['user_name'] is None):
             self.config = None
             log.error('missing "user_name" in "mqtt_logger" config section')
         if 'log_values' in config:


### PR DESCRIPTION
Allows connections to brokers with username/password auth enabled.